### PR TITLE
Trying to migrate to Elastic 2.0.0 (Work In Progress)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lucene.version>4.10.4</lucene.version>
-        <elasticsearch.version>1.5.0</elasticsearch.version>
+        <elasticsearch.version>2.0.0</elasticsearch.version>
         <hebmorph.version>2.0.3</hebmorph.version>
     </properties>
     

--- a/src/main/java/com/code972/elasticsearch/plugins/AnalysisPlugin.java
+++ b/src/main/java/com/code972/elasticsearch/plugins/AnalysisPlugin.java
@@ -1,20 +1,12 @@
 package com.code972.elasticsearch.plugins;
 
 import com.code972.elasticsearch.rest.action.RestHebrewAnalyzerCheckWordAction;
-import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalysisModule;
-import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestModule;
 
-/**
- * Created with IntelliJ IDEA.
- * User: synhershko
- * Date: 10/25/12
- * Time: 3:41 PM
- * To change this template use File | Settings | File Templates.
- */
-public class AnalysisPlugin extends AbstractPlugin {
+public class AnalysisPlugin extends Plugin {
 
     /**
      * Attempts to load a dictionary from paths specified in elasticsearch.yml.
@@ -39,12 +31,13 @@ public class AnalysisPlugin extends AbstractPlugin {
         return "Hebrew analyzer powered by HebMorph";
     }
 
-    @Override
-    public void processModule(Module module) {
-        if (module instanceof AnalysisModule) {
-            ((AnalysisModule) module).addProcessor(new HebrewAnalysisBinderProcessor());
-        } else if (module instanceof RestModule) {
-            ((RestModule) module).addRestAction(RestHebrewAnalyzerCheckWordAction.class);
-        }
+    /* Invoked on component assembly. */
+    public void onModule(AnalysisModule analysisModule) {
+        analysisModule.addProcessor(new HebrewAnalysisBinderProcessor());
+    }
+
+    /* Invoked on component assembly. */
+    public void onModule(RestModule restModule) {
+        restModule.addRestAction(RestHebrewAnalyzerCheckWordAction.class);
     }
 }


### PR DESCRIPTION
Hi!

Attached is a try to start migrating to Elastic 2.0.0.

I believe more work needs to be done since Lucene was updated to 5.2.1.

A [`plugin-descriptor.properties`](https://www.elastic.co/guide/en/elasticsearch/plugins/2.0/plugin-authors.html#_plugin_descriptor_file) file should be added as well:

    # Elasticsearch plugin descriptor file
    jvm=true
    classname=com.code972.elasticsearch.plugins.AnalysisPlugin
    elasticsearch.version=2.0
    java.version=1.8
    name=elasticsearch-analysis-hebrew
    version=1.8-SNAPSHOT
    description=Hebrew analyzer powered by HebMorph

template:

    # Elasticsearch plugin descriptor file
    jvm=true
    elasticsearch.version=${elasticsearch.version}
    java.version=${maven.compiler.target}
    name=${elasticsearch.plugin.name}
    version=${project.version}
    classname=${elasticsearch.plugin.classname}
    description=${project.description}

Thank you!
