### PR TITLE
add permission for accessing the directory itself

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -1,4 +1,5 @@
 grant { 
     permission java.io.FilePermission "/var/lib/hebmorph/dictionary.dict", "read";
+    permission java.io.FilePermission "/var/lib/hspell-data-files", "read";
     permission java.io.FilePermission "/var/lib/hspell-data-files/*", "read";
 };


### PR DESCRIPTION
The changes you made for #18 to `plugin-security.policy` still fails with this:

```
ElasticsearchException[Failed to load plugin class [com.code972.elasticsearch.plugins.AnalysisPlugin]]; nested: InvocationTargetException; nested: AccessControlException[access denied ("java.io.FilePermission" "/var/lib/hspell-data-files" "read")];
```

Note that it's on the directory now and not the specific file (like it was in #18). This change fixes it.